### PR TITLE
ghq root とパスを現況に合わせて最新化 (Apple Silicon)

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -50,7 +50,6 @@
 	binary = true
 	textconv = $GOPATH/bin/git-xlsx-textconv
 [ghq]
-	root = ~/workspace
-	root = ~/work/src
+	root = ~/src
 [hub]
 	protocol = https

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,5 +1,5 @@
-# tmux起動時のシェルをzshにする
-set-option -g default-shell /usr/local/bin/fish
+# tmux起動時のシェルを fish にする (Apple Silicon の Homebrew は /opt/homebrew)
+set-option -g default-shell /opt/homebrew/bin/fish
 
 # tmuxを256色表示できるようにする
 set-option -g default-terminal screen-256color

--- a/README.md
+++ b/README.md
@@ -1,9 +1,24 @@
-# How to install
+# dotfiles
 
-```
-git clone https://github.com/tomkenta/dotfiles dotfiles
-cd dotfiles/
+普段の Mac 環境の dotfiles。通常は [mac-setting](https://github.com/tomkenta/mac-setting)
+の `setting.sh` が ansible 経由で自動取得・シンボリックリンクするため、単体での操作は不要。
+
+## 手動でセットアップする場合
+
+ghq で取得（`~/src` 配下に置かれる）してリンクスクリプトを実行:
+
+```sh
+ghq get tomkenta/dotfiles
+cd ~/src/github.com/tomkenta/dotfiles
 ./install.sh
 ```
 
+`install.sh` が `~/.zprofile` `.gitconfig` `.vimrc` `.tmux.conf` `.config` 等を
+ホームディレクトリにシンボリックリンクする。
 
+## 含まれる主な設定
+- `.zprofile` — Apple Silicon の Homebrew (`/opt/homebrew`) に PATH を通す
+- `.config/fish/config.fish` — fish のエイリアス・プロンプト・anyenv 初期化
+- `.gitconfig` — git エイリアス各種、ghq root = `~/src`
+- `.tmux.conf` — prefix を C-q、tpm プラグイン
+- `.vimrc` / `.config/karabiner/` ほか

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,17 @@
 #!/bin/sh
-ln -sf ~/dotfiles/.vimrc ~/.vimrc
-ln -sf ~/dotfiles/.gitconfig ~/.gitconfig
-ln -sf ~/dotfiles/.gitattributes ~/.gitattributes
-ln -sf ~/dotfiles/.vscode ~/.vscode
-ln -sf ~/work/settings/dotfiles/.config/fish/config.fish ~/.config/fish/config.fish
-ln -sf ~/dotfiles/.zprofile ~/.zprofile
+# dotfiles を手動でシンボリックリンクする場合のスクリプト。
+# (通常は mac-setting の ansible (dotfiles role) が自動でリンクするため任意)
+#
+# 前提: このリポジトリは ghq root 配下 (~/src/github.com/tomkenta/dotfiles) にある。
+
+DOTFILES="$HOME/src/github.com/tomkenta/dotfiles"
+
+ln -sf "$DOTFILES/.zprofile"          ~/.zprofile
+ln -sf "$DOTFILES/.bash_profile"      ~/.bash_profile
+ln -sf "$DOTFILES/.bashrc"            ~/.bashrc
+ln -sf "$DOTFILES/.vimrc"             ~/.vimrc
+ln -sf "$DOTFILES/.tmux.conf"         ~/.tmux.conf
+ln -sf "$DOTFILES/.gitconfig"         ~/.gitconfig
+ln -sf "$DOTFILES/.gitattributes"     ~/.gitattributes
+ln -sf "$DOTFILES/.gitignore_global"  ~/.gitignore_global
+ln -sf "$DOTFILES/.config"            ~/.config


### PR DESCRIPTION
新Macキッティングに向け、dotfiles のパスを現況に合わせて最新化。[mac-setting#43](https://github.com/tomkenta/mac-setting/pull/43) と対。

## 変更点
- **ghq root**: 旧 `~/work/src` / `~/workspace` → 現行 `~/src` に統一(`.gitconfig`)。
- **install.sh**: 壊れていたパス(`~/dotfiles`, `~/work/settings/dotfiles`)を `~/src/github.com/tomkenta/dotfiles` に修正。リンク対象も整理。
- **.tmux.conf**: fish のパスを `/usr/local/bin/fish` → `/opt/homebrew/bin/fish` (Apple Silicon)。
- **README**: ghq 前提のセットアップ手順に刷新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)