### PR TITLE
install.sh: ~/.config 丸ごとリンクを個別リンクに修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode/extensions/
+# fisher は setup.sh がダウンロードする生成ファイルのため追跡しない
+.config/fish/functions/fisher.fish

--- a/install.sh
+++ b/install.sh
@@ -1,17 +1,18 @@
 #!/bin/sh
 # dotfiles を手動でシンボリックリンクする場合のスクリプト。
-# (通常は mac-setting の ansible (dotfiles role) が自動でリンクするため任意)
+# (通常は mac-setting の setup.sh が自動でリンクするため任意)
 #
 # 前提: このリポジトリは ghq root 配下 (~/src/github.com/tomkenta/dotfiles) にある。
 
 DOTFILES="$HOME/src/github.com/tomkenta/dotfiles"
 
-ln -sf "$DOTFILES/.zprofile"          ~/.zprofile
-ln -sf "$DOTFILES/.bash_profile"      ~/.bash_profile
-ln -sf "$DOTFILES/.bashrc"            ~/.bashrc
-ln -sf "$DOTFILES/.vimrc"             ~/.vimrc
-ln -sf "$DOTFILES/.tmux.conf"         ~/.tmux.conf
-ln -sf "$DOTFILES/.gitconfig"         ~/.gitconfig
-ln -sf "$DOTFILES/.gitattributes"     ~/.gitattributes
-ln -sf "$DOTFILES/.gitignore_global"  ~/.gitignore_global
-ln -sf "$DOTFILES/.config"            ~/.config
+for f in .zprofile .bash_profile .bashrc .vimrc .tmux.conf \
+          .gitconfig .gitattributes .gitignore_global; do
+  ln -sf "$DOTFILES/$f" ~/"$f"
+done
+
+# ~/.config は丸ごとリンクせず必要なサブディレクトリのみリンク
+# (丸ごとリンクすると既存の他ツール設定を壊す)
+mkdir -p ~/.config
+ln -sfn "$DOTFILES/.config/fish"      ~/.config/fish
+ln -sfn "$DOTFILES/.config/karabiner" ~/.config/karabiner

--- a/install.sh
+++ b/install.sh
@@ -6,13 +6,21 @@
 
 DOTFILES="$HOME/src/github.com/tomkenta/dotfiles"
 
-for f in .zprofile .bash_profile .bashrc .vimrc .tmux.conf \
-          .gitconfig .gitattributes .gitignore_global; do
+for f in \
+  .zprofile \
+  .bash_profile \
+  .bashrc \
+  .vimrc \
+  .tmux.conf \
+  .gitconfig \
+  .gitattributes \
+  .gitignore_global; do
   ln -sf "$DOTFILES/$f" ~/"$f"
 done
 
-# ~/.config は丸ごとリンクせず必要なサブディレクトリのみリンク
+# ~/.config は丸ごとリンクせず、このリポジトリで管理しているサブディレクトリのみリンク
 # (丸ごとリンクすると既存の他ツール設定を壊す)
+# 対象: dotfiles/.config/ 配下にあるディレクトリのみ = fish, karabiner
 mkdir -p ~/.config
 ln -sfn "$DOTFILES/.config/fish"      ~/.config/fish
 ln -sfn "$DOTFILES/.config/karabiner" ~/.config/karabiner


### PR DESCRIPTION
## 概要
コードレビューで指摘された `~/.config` の symlink 問題を修正。mac-setting の Ansible 廃止 ([#44](https://github.com/tomkenta/mac-setting/pull/44)) に合わせた dotfiles 側の対応。

## 変更点
- `install.sh`: `ln -sf "$DOTFILES/.config" ~/.config` を廃止
  → `~/.config/fish` と `~/.config/karabiner` を個別にリンクする方式に変更
- `.gitignore`: `fisher.fish` を追加（`setup.sh` がダウンロードする生成ファイルのため追跡しない）

## なぜ問題だったか
macOS (BSD `ln`) では `ln -sf source existing_real_dir` を実行すると、ディレクトリを置き換えるのではなく**内部に**シンボリックリンクを作る（`~/.config/.config` が作られる）。`~/.config` は fish/Karabiner/VS Code 等で既に存在しているため、dotfiles の設定が一切反映されないサイレント障害が起きていた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)