### PR TITLE
README: 陳腐化した記述を現況に同期

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dotfiles
 
 普段の Mac 環境の dotfiles。通常は [mac-setting](https://github.com/tomkenta/mac-setting)
-の `setting.sh` が ansible 経由で自動取得・シンボリックリンクするため、単体での操作は不要。
+の `setup.sh` が ansible 経由で自動取得・シンボリックリンクするため、単体での操作は不要。
 
 ## 手動でセットアップする場合
 
@@ -13,12 +13,19 @@ cd ~/src/github.com/tomkenta/dotfiles
 ./install.sh
 ```
 
-`install.sh` が `~/.zprofile` `.gitconfig` `.vimrc` `.tmux.conf` `.config` 等を
-ホームディレクトリにシンボリックリンクする。
+`install.sh` が `~/.zprofile` `.zshrc` `.gitconfig` `.vimrc` `.tmux.conf` 等をホームディレクトリに
+シンボリックリンクする。`~/.config` は丸ごとリンクせず、このリポジトリで管理する
+サブディレクトリ (`fish` / `karabiner` / `ghostty`) のみを個別にリンクする
+（丸ごとリンクすると他ツールの既存設定を壊すため）。
+
+秘密情報（API キー等）はリポジトリに含めない。`~/.zshrc` から `~/.zshrc.local`
+（gitignore 済み）を読み込む構成のため、鍵類はそちらに置く。
 
 ## 含まれる主な設定
 - `.zprofile` — Apple Silicon の Homebrew (`/opt/homebrew`) に PATH を通す
 - `.config/fish/config.fish` — fish のエイリアス・プロンプト・anyenv 初期化
 - `.gitconfig` — git エイリアス各種、ghq root = `~/src`
-- `.tmux.conf` — prefix を C-q、tpm プラグイン
+- `.tmux.conf` — prefix を C-q、ステータスバーのカスタマイズ、vim 風ペイン操作・コピーモード
+- `.zshrc` — ghq + peco のリポジトリ移動、秘密情報は `~/.zshrc.local` に分離
+- `.config/ghostty/config` — Ghostty ターミナルの設定
 - `.vimrc` / `.config/karabiner/` ほか


### PR DESCRIPTION
## 概要
現況同期(PR #13)後も `README.md` だけ古い記述が残っていたため、実態に合わせて修正。

## 変更点
- mac-setting のスクリプト名 `setting.sh` → `setup.sh`（`install.sh` のコメントと統一）
- `.config` を「丸ごとリンク」ではなく `fish` / `karabiner` / `ghostty` を個別リンクする旨に修正
- `.tmux.conf` の「tpm プラグイン」は実ファイルに存在しないため、実機能（ステータスバー・vim 風キーバインド）の記述に置換
- 現況同期で追加された `.zshrc` / `ghostty` 設定と、秘密情報を `~/.zshrc.local` に分離する方針を追記

## 確認
- ghostty config・`.zshrc`(ghq+peco) の実在を確認済み
- 追跡対象ファイルに秘密情報（API キー等）が含まれないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)