### PR TITLE
git: identity焼き付き防止 + 全repoのgitleaksフック

### DIFF
--- a/.config/git/hooks/pre-commit
+++ b/.config/git/hooks/pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# 全 repo 共通 pre-commit（gitleaks）。設定は $HOME/.gitleaks.toml（あれば）。
+command -v gitleaks >/dev/null 2>&1 || exit 0
+cfg="$HOME/.gitleaks.toml"
+args=(protect --staged --redact --no-banner)
+[ -f "$cfg" ] && args+=(--config "$cfg")
+gitleaks "${args[@]}" || {
+  echo "❌ gitleaks: 機密の可能性を検出。コミット中止。誤検知なら git commit --no-verify。" >&2
+  exit 1
+}

--- a/.config/git/hooks/pre-push
+++ b/.config/git/hooks/pre-push
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# 全 repo 共通 pre-push（gitleaks）。push 対象の "新規" commit のみスキャン。
+command -v gitleaks >/dev/null 2>&1 || exit 0
+cfg="$HOME/.gitleaks.toml"; base=(detect --no-banner --redact)
+[ -f "$cfg" ] && base+=(--config "$cfg")
+z=0000000000000000000000000000000000000000; fail=0
+while read -r l_ref l_sha r_ref r_sha; do
+  [ "$l_sha" = "$z" ] && continue
+  if [ "$r_sha" = "$z" ]; then
+    opts=(--log-opts="$l_sha --not --remotes")   # 新規ブランチ: 既push分を除外し全履歴再スキャンを防ぐ
+  else
+    opts=(--log-opts="$r_sha..$l_sha")
+  fi
+  gitleaks "${base[@]}" "${opts[@]}" || fail=1
+done
+[ "$fail" -eq 0 ] || { echo "❌ gitleaks(pre-push): 機密の可能性を検出。push中止。誤検知なら git push --no-verify。" >&2; exit 1; }

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,3 +1,8 @@
+[user]
+	# identity(name/email) は公開 dotfiles に持たせない方針（各マシンでローカル設定）。
+	# 未設定のまま commit すると `名前@ホスト名` が焼き付くため useConfigOnly で防ぐ。
+	# (未設定なら commit がエラーになる = 社内ホスト名などの混入事故対策)
+	useConfigOnly = true
 [alias]
 	st = status
 	lg = log
@@ -39,6 +44,8 @@
 	editor = vim
 	attributesfile = ~/.gitattributes
 	excludesfile = ~/.gitignore_global
+	# 全 repo 共通の pre-commit / pre-push フック（gitleaks スキャン）
+	hooksPath = ~/.config/git/hooks
 [filter "lfs"]
 	clean = git-lfs clean %f
 	smudge = git-lfs smudge %f
@@ -50,3 +57,7 @@
 	root = ~/src
 [hub]
 	protocol = https
+[include]
+	# 各マシン固有の設定（identity 等）はここに分離。dotfiles の外・非追跡。
+	# 例) ~/.gitconfig.local に [user] name/email を記載（存在しなければ git は無視）。
+	path = ~/.gitconfig.local


### PR DESCRIPTION
## 概要
全 repo 共通のシークレット混入防止（identity 焼き付き防止 + gitleaks フック）。
具体的な機密値はどの repo にも置かず、ローカル限定の `~/.gitleaks.toml` で扱う設計。

## 変更
- `.gitconfig`:
  - `[user] useConfigOnly = true` … identity 未設定での commit を禁止（`名前@ホスト名` の焼き付き防止）。identity 自体は公開 dotfiles に持たせない
  - `[core] hooksPath = ~/.config/git/hooks`
  - `[include] path = ~/.gitconfig.local` … 各マシンの identity 等を dotfiles 外に分離（無ければ git は無視）
- `.config/git/hooks/{pre-commit,pre-push}`: gitleaks スキャン
  - pre-commit: ステージ差分
  - pre-push: push 対象の新規 commit のみ（既 push 分は除外し全履歴再スキャンを回避）
  - 設定は `$HOME/.gitleaks.toml`（無ければ no-op）

## 補足
- gitleaks の具体ルール（前職ドメイン等の機密）は追跡しない（`~/.gitleaks.toml` にローカル限定）
- 各マシンで identity を使う場合は `~/.gitconfig.local` に `[user] name/email` を記載

🤖 Generated with [Claude Code](https://claude.com/claude-code)