### PR TITLE
[codex] Add Codex status line config

### DIFF
--- a/.codex/apply-config.sh
+++ b/.codex/apply-config.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+set -eu
+
+CODEX_CONFIG="${CODEX_CONFIG:-$HOME/.codex/config.toml}"
+
+mkdir -p "$(dirname "$CODEX_CONFIG")"
+touch "$CODEX_CONFIG"
+
+tmp=$(mktemp "${TMPDIR:-/tmp}/codex-config.XXXXXX")
+
+awk '
+BEGIN {
+  in_tui = 0
+  seen_tui = 0
+  wrote_managed = 0
+  skip_value = 0
+}
+
+function is_section(line) {
+  return line ~ /^\[[^]]+\][[:space:]]*$/
+}
+
+function print_managed() {
+  print "# Managed by tomkenta/dotfiles. Keep local Codex state, MCP, and plugin settings elsewhere in this file."
+  print "status_line = [\"model-with-reasoning\", \"context-remaining\", \"current-dir\", \"git-branch\"]"
+  print "terminal_title = [\"project\", \"git-branch\", \"status\"]"
+  wrote_managed = 1
+}
+
+{
+  if (skip_value) {
+    if ($0 ~ /\]/) {
+      skip_value = 0
+    }
+    next
+  }
+
+  if ($0 ~ /^\[tui\][[:space:]]*$/) {
+    print
+    in_tui = 1
+    seen_tui = 1
+    wrote_managed = 0
+    next
+  }
+
+  if (in_tui && is_section($0)) {
+    if (!wrote_managed) {
+      print_managed()
+    }
+    in_tui = 0
+  }
+
+  if (in_tui && $0 ~ /^[[:space:]]*# Managed by tomkenta\/dotfiles\./) {
+    next
+  }
+
+  if (in_tui && $0 ~ /^[[:space:]]*(status_line|terminal_title)[[:space:]]*=/) {
+    if ($0 ~ /\[[[:space:]]*$/ && $0 !~ /\]/) {
+      skip_value = 1
+    }
+    next
+  }
+
+  print
+}
+
+END {
+  if (in_tui && !wrote_managed) {
+    print_managed()
+  }
+
+  if (!seen_tui) {
+    print ""
+    print "[tui]"
+    print_managed()
+  }
+}
+' "$CODEX_CONFIG" > "$tmp"
+
+mv "$tmp" "$CODEX_CONFIG"
+echo "Updated $CODEX_CONFIG"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,4 @@
+[tui]
+# Show enough context in the Codex footer to avoid working on the wrong branch.
+status_line = ["model-with-reasoning", "context-remaining", "current-dir", "git-branch"]
+terminal_title = ["project", "git-branch", "status"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ zsh ブートストラップ (`~/.zshenv`) のみをリンクする。zsh / git 
 管理ファイルのみリンク」でセットアップする（履歴や `config.local` 等がリポジトリに混入しないため）。
 あわせて zsh 強化ツール（`starship` / `zsh-autosuggestions` / `zsh-syntax-highlighting` /
 `zsh-completions` / `fzf`）を brew で導入する（未導入でも `.zshrc` がガードしており壊れない）。
+Codex は `~/.codex/config.toml` にローカル状態が混在するため丸ごとリンクせず、`install.sh` が
+`[tui]` の status line だけをマージする。
 
 秘密情報（API キー等）はリポジトリに含めない。`.zshrc` から `~/.config/zsh/.zshrc.local`
 （gitignore 済み）を読み込む構成のため、鍵類はそちらに置く。
@@ -32,6 +34,7 @@ zsh ブートストラップ (`~/.zshenv`) のみをリンクする。zsh / git 
 - `~/.config/git/{config,attributes,ignore,hooks}` — git はネイティブで XDG を参照。
   identity 等マシン固有設定は `config.local`（非追跡）に分離
 - `~/.config/tmux/tmux.conf` — tmux はネイティブで XDG を参照
+- `~/.codex/config.toml` — Codex は既存設定を保持しつつ `[tui]` の status line だけを更新
 
 ## 含まれる主な設定
 - `.config/zsh/.zprofile` — Apple Silicon の Homebrew (`/opt/homebrew`) に PATH を通す
@@ -44,6 +47,8 @@ zsh ブートストラップ (`~/.zshenv`) のみをリンクする。zsh / git 
 - `.config/git/config` — git エイリアス各種、ghq root = `~/src`、identity は焼き付き防止、
   diff ページャに **delta**（行番号・色付き）
 - `.config/tmux/tmux.conf` — prefix を C-q、ステータスバー、vim 風ペイン操作・コピーモード
+- `.codex/config.toml` / `.codex/apply-config.sh` — Codex のフッターに model / context /
+  current dir / git branch を表示
 - `.config/fish/config.fish` — 旧 fish 設定（移行元・参考用に残置）
 - `.config/ghostty/config` — Ghostty ターミナルの設定
 - `.vimrc` / `.config/karabiner/` ほか

--- a/install.sh
+++ b/install.sh
@@ -85,3 +85,7 @@ fi
 mkdir -p ~/.claude
 ln -sf "$DOTFILES/.claude/statusline.sh"         ~/.claude/statusline.sh
 ln -sf "$DOTFILES/.claude/statusline-command.sh" ~/.claude/statusline-command.sh
+
+# Codex は config.toml にローカル状態/MCP/trust 設定が混在するため丸ごとリンクしない。
+# 既存設定を残し、管理したい TUI status line だけをマージする。
+sh "$DOTFILES/.codex/apply-config.sh"


### PR DESCRIPTION
## Summary
- add dotfiles-managed Codex TUI status line settings
- add an apply script that updates only the `[tui]` section in `~/.codex/config.toml`
- wire the Codex config merge into `install.sh` and document the behavior in `README.md`

## Why
Codex user config mixes local state such as MCP, plugin, trust, and desktop settings with user preferences. Managing the whole file as a symlink is risky, but the status line still needs to be standardized so the current branch is always visible.

## Impact
Codex sessions will show model, remaining context, current directory, and git branch in the footer after the managed config is applied. Existing local Codex state remains intact.

## Validation
- `sh -n .codex/apply-config.sh`
- `codex --strict-config --help`
- applied the script to `~/.codex/config.toml` and verified the managed `[tui]` block was inserted